### PR TITLE
Updated get_frame_time() function. 

### DIFF
--- a/video_getter_cv2.py
+++ b/video_getter_cv2.py
@@ -237,17 +237,21 @@ class VideoStream:
         self.pauseTime = None
         self.start()
 
-    def get_frame_time(self, clock):
+    def get_frame_time(self, clock, do_set_start_time=False):
         """
         Parameters
         ----------
         clock : utils.clock.Clock object
+            Clock object
+        do_set_start_time : bool 
+            Flag to determine whether to get 'current' time in video/stream, or present day time.
+
         Returns
         ----------
-         - If source_type is a file, returns time elapsed since start of video in milliseconds
+         - If do_set_start_time is True, returns time elapsed since start of video in milliseconds
          - Else, returns current unix time, in milliseconds
          """        
-        if self.source_type == 'file':
+        if do_set_start_time:
             return self.stream.get(cv2.CAP_PROP_POS_MSEC)
         else: 
             return int(1000 * clock.get_now_SGT_unixts())

--- a/video_getter_vlc.py
+++ b/video_getter_vlc.py
@@ -141,17 +141,22 @@ class VideoStream(video_getter_cv2.VideoStream):
         self.pauseTime = None
         self.start()
 
-    def get_frame_time(self, clock):
+    def get_frame_time(self, clock, do_set_start_time=False):
         """
         Parameters
         ----------
         clock : utils.clock.Clock object
+            Clock object
+        do_set_start_time : bool 
+            Flag to determine whether to get 'current' time in video/stream, or present day time.
+
         Returns
         ----------
-         - If source_type is a file, returns time elapsed since start of video in milliseconds
+         - If do_set_start_time is True, returns time elapsed since start of video in milliseconds
          - Else, returns current unix time, in milliseconds
-         """     
-        if self.source_type == 'file':
+         """      
+        if do_set_start_time:
             return self.vlc_player.get_time()
         else: 
             return int(1000 * clock.get_now_SGT_unixts())
+


### PR DESCRIPTION
Now, a flag is used to determine whether the frame time should be the video time or the current time.